### PR TITLE
Fixed module declaration issue

### DIFF
--- a/hmsclient/client.go
+++ b/hmsclient/client.go
@@ -21,7 +21,7 @@ import (
     "strconv"
     "strings"
 
-    "git.apache.org/thrift.git/lib/go/thrift"
+    "github.com/apache/thrift/lib/go/thrift"
     "github.com/akolb1/gometastore/hmsclient/thrift/gen-go/hive_metastore"
 )
 


### PR DESCRIPTION
When you try `go get github.com/akolb1/gometastore/hmsbench` you will get error

```
go get: git.apache.org/thrift.git@v0.15.0: parsing go.mod:
        module declares its path as: github.com/apache/thrift
                but was required as: git.apache.org/thrift.git
```